### PR TITLE
Remove axios from dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-react": "^7.12.10",
     "@babel/register": "^7.12.10",
-    "axios": "^0.21.1",
     "axios-mock-adapter": "^1.16.0",
     "babel-loader": "^8.2.2",
     "chai": "^4.2.0",


### PR DESCRIPTION
This seems to resolve the issue for me. Note that there is another issue which is that you are not consistently following uppercase / lowercase in your code. I got an error because you've named a file `PrimaryStats.js` but in your code you are calling it `require('.../primaryStats.js')`

Try pulling this in and redeploy. You might need to resolve these case errors before your app starts but you should no longer get the axios error.